### PR TITLE
version compatibility

### DIFF
--- a/gain/Cargo.toml
+++ b/gain/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 baseplug = { git = "https://github.com/wrl/baseplug.git", rev = "9cec68f31cca9c0c7a1448379f75d92bbbc782a8" }
-baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "e7a6c661eff90000b5a62d28fb8e1eec3997d2aa" }
+baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "f6e99e9aa6f5aeb6b721cb05e4d882a51d995909" }
 iced_baseview = { git = "https://github.com/BillyDM/iced_baseview", branch="main", features=["canvas"] }
 iced_audio = "0.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/gain/src/lib.rs
+++ b/gain/src/lib.rs
@@ -102,7 +102,7 @@ impl baseplug::PluginUI for Gain {
     }
 
     fn ui_close(mut handle: Self::Handle) {
-        handle.close_window().unwrap();
+        handle.close_window();
     }
 }
 

--- a/gain/src/ui/mod.rs
+++ b/gain/src/ui/mod.rs
@@ -1,6 +1,7 @@
 use iced_audio::{knob, tick_marks, Knob, LogDBRange, Normal};
 use iced_baseview::{
     executor, Align, Color, Column, Command, Container, Element, Length, Row, Rule, Text,
+    WindowQueue,
 };
 
 mod style;
@@ -56,7 +57,11 @@ impl iced_baseview::Application for GainUI {
         )
     }
 
-    fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
+    fn update(
+        &mut self,
+        _window_queue: &mut WindowQueue,
+        message: Self::Message,
+    ) -> Command<Self::Message> {
         match message {
             Message::GainLeftChanged(normal) => {
                 let value = self.db_range.unmap_to_value(normal);


### PR DESCRIPTION
This PR resolves the following compile errors:

```
$ cargo +nightly build --package gain
    Updating git repository `https://github.com/RustAudio/baseview.git`
   Compiling baseview v0.1.0 (https://github.com/RustAudio/baseview.git?rev=e7a6c661eff90000b5a62d28fb8e1eec3997d2aa#e7a6c661)
   Compiling gain v0.1.0 (/home/jp/proj/rust/iced-baseplug-examples/gain)
error[E0050]: method `update` has 2 parameters but the declaration in trait `iced_baseview::Application::update` has 3
  --> gain/src/ui/mod.rs:59:15
   |
59 |     fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 3 parameters, found 2
   |
   = note: `update` from trait: `fn(&mut Self, &mut WindowQueue, <Self as Application>::Message) -> iced_baseview::Command<<Self as Application>::Message>`

error[E0308]: mismatched types
  --> gain/src/lib.rs:83:21
   |
83 |               window: WindowOpenOptions {
   |  _____________________^
84 | |                 title: String::from("iced-baseplug-examples gain"),
85 | |                 size: Size::new(Self::ui_size().0 as f64, Self::ui_size().1 as f64),
86 | |                 scale: WindowScalePolicy::SystemScaleFactor,
87 | |             },
   | |_____________^ expected struct `baseview::window_open_options::WindowOpenOptions`, found struct `WindowOpenOptions`
   |
   = note: perhaps two different versions of crate `baseview` are being used?

error[E0599]: no method named `unwrap` found for unit type `()` in the current scope
   --> gain/src/lib.rs:105:31
    |
105 |         handle.close_window().unwrap();
    |                               ^^^^^^ method not found in `()`

Some errors have detailed explanations: E0050, E0308, E0599.
For more information about an error, try `rustc --explain E0050`.
error: could not compile `gain` due to 3 previous errors
```

At time of writing, `f6e99e9aa6f5aeb6b721cb05e4d882a51d995909` is the [most recent commit on baseview's main branch](https://github.com/RustAudio/baseview/commit/f6e99e9aa6f5aeb6b721cb05e4d882a51d995909)